### PR TITLE
feat: implement changelog regeneration

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 import minimist from 'minimist'
 
-const { _, dryRun, noPush, noTag } = minimist(process.argv.slice(2))
+const { _, dryRun, noPush, noTag, regenChangelog } = minimist(process.argv.slice(2))
 
-export { _, dryRun, noPush, noTag }
+export { _, dryRun, noPush, noTag, regenChangelog }

--- a/src/get-commits.js
+++ b/src/get-commits.js
@@ -20,14 +20,14 @@ export const getCommits = async (packageName, originTag) => {
   const tags = await getGitTags(packageName)
 
   const fromTag = originTag || tags.pop()
-  const toTag = originTag ? tags[tags.indexOf(originTag) + 1] : 'HEAD'
+  const toTag = originTag ? tags[tags.indexOf(originTag) + 1] + '~1' : 'HEAD'
 
   originTag
     ? log(chalk`{blue Gathering commits between} {grey ${fromTag} and {grey ${toTag}}}`)
     : log(chalk`{blue Gathering commits since} {grey ${fromTag}}`)
 
   // NOTE: ~1 means to not include release commit
-  let params = ['--no-pager', 'log', `${fromTag}..${toTag}~1`, '--format=%B%n-hash-%n%H🐒💨🙊']
+  let params = ['--no-pager', 'log', `${fromTag}..${toTag}`, '--format=%B%n-hash-%n%H🐒💨🙊']
   const commitSubjectRegex = releaseOnCwd ? '' : `\\(${packageName}\\)`
   const commitRegex = new RegExp(`^[\\w\\!]+${commitSubjectRegex}`, 'i')
   const { stdout } = await execa('git', params)

--- a/src/get-git-tags.js
+++ b/src/get-git-tags.js
@@ -1,0 +1,15 @@
+import { basename } from 'path'
+
+import execa from 'execa'
+
+export const getGitTags = async packageName => {
+  // TODO: Deduplicate this
+  const releaseOnCwd = packageName === basename(process.cwd())
+  const tagPrefix = releaseOnCwd ? '' : packageName + '-'
+
+  let params = ['tag', '--list', `${tagPrefix}v*`, '--sort', '-v:refname']
+  const { stdout } = await execa('git', params)
+  const tags = stdout.split('\n').reverse()
+
+  return tags
+}

--- a/src/get-new-version.js
+++ b/src/get-new-version.js
@@ -2,6 +2,7 @@ import chalk from 'chalk'
 import semver from 'semver'
 
 const { log } = console
+
 export const getNewVersion = (version, commits) => {
   log(chalk`{blue Determining new version}`)
   // TODO: Review

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,9 @@ import { updatePackage } from './update-package'
 import { updateChangelog } from './update-changelog'
 import { commitChanges } from './commit-changes'
 import { tag } from './tag'
+import { regenerateChangelog } from './regenerate-changelog'
 import { push } from './push'
-import { _, dryRun } from './cli'
+import { _, dryRun, regenChangelog } from './cli'
 
 const { log } = console
 
@@ -26,21 +27,22 @@ try {
 
   dryRun && log(chalk`{magenta DRY RUN:} No files will be modified`)
 
+  regenChangelog && (await regenerateChangelog(cwd, packageName))
+
   log(chalk`{cyan Publishing \`${packageName}\`} from {grey packages/${packageName}}`)
 
   const commits = await getCommits(packageName)
 
-  if (!commits.length) {
+  if (!commits.length)
     throw chalk`\n{red No commits found!} did you mean to publish ${packageName}?`
-  }
 
   log(chalk`{blue Found} {bold ${commits.length}} commits`)
 
   const newVersion = getNewVersion(packageJson.version, commits)
 
   log(chalk`{blue New version}: ${newVersion}\n`)
+
   await updatePackage(cwd, packageJson, newVersion)
-  // FIXME: probably `await` is not needed here
   updateChangelog(commits, cwd, packageName, newVersion)
   await commitChanges(cwd, packageName, newVersion)
   await tag(cwd, packageName, newVersion)

--- a/src/regenerate-changelog.js
+++ b/src/regenerate-changelog.js
@@ -1,0 +1,26 @@
+import chalk from 'chalk'
+
+const { log } = console
+
+import { getGitTags } from './get-git-tags'
+import { getCommits } from './get-commits'
+import { updateChangelog } from './update-changelog'
+
+export const regenerateChangelog = async (cwd, packageName) => {
+  log(chalk`{magenta REGENERATE:} Changelog will be generated from scratch`)
+
+  const tags = await getGitTags(packageName)
+
+  if (!tags.length) throw chalk`\n{red No Git tags found!}`
+
+  for (let [i, tag] of tags.entries()) {
+    const toTag = tags[i + 1]
+    if (!toTag) break
+    const [, version] = toTag.split('v')
+    const commits = await getCommits(packageName, tag)
+
+    log(chalk`{blue Found} {bold ${commits.length}} commits`)
+
+    updateChangelog(commits, cwd, packageName, version)
+  }
+}

--- a/src/regenerate-changelog.js
+++ b/src/regenerate-changelog.js
@@ -1,3 +1,6 @@
+import { join } from 'path'
+import { unlinkSync } from 'fs'
+
 import chalk from 'chalk'
 
 const { log } = console
@@ -12,6 +15,8 @@ export const regenerateChangelog = async (cwd, packageName) => {
   const tags = await getGitTags(packageName)
 
   if (!tags.length) throw chalk`\n{red No Git tags found!}`
+
+  unlinkSync(join(cwd, 'CHANGELOG.md'))
 
   for (let [i, tag] of tags.entries()) {
     const toTag = tags[i + 1]

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -26,7 +26,9 @@ export const updateChangelog = (commits, cwd, packageName, version) => {
     // Maybe transform these in links leading to actual issues/commits
     const ref = /\(#\d+\)/.test(header) ? '' : ` (${hash.substring(0, 7)})`
     // Remove package name as it's redundant inside the package changelog
-    const message = header.trim().replace(`(${packageName})`, '') + ref
+    // Remove the commit type as it's redundant inside it's respective changelog section
+    const message = header.trim().replace(`(${packageName})`, '').replace(`${type}: `, '') + ref
+    log(message, type)
     if (breaking) notes.breaking.push(message)
     else if (type === 'fix') notes.fixes.push(message)
     else if (type === 'feat') notes.features.push(message)

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -13,7 +13,7 @@ export const updateChangelog = (commits, cwd, packageName, version) => {
   // TODO: Deduplicate this
   const releaseOnCwd = packageName === basename(process.cwd())
 
-  const title = `# ${releaseOnCwd ? '' : `\`${packageName}\``} Changelog`
+  const title = `# ${releaseOnCwd ? 'Changelog' : `\`${packageName}\` changelog`}`
   const [date] = new Date().toISOString().split('T')
   const logPath = join(cwd, 'CHANGELOG.md')
 


### PR DESCRIPTION
### Description

Basically, regenerating a changelog means entirely deleting the old one and rewriting entry by entry from scratch (instead of just appending new entries to a already existing file), by analysing every commit made between each release

### Use cases

This is really useful for ongoing projects that need to adopt a new changelog generation tool without completely messing the already existing one

### Considerations

Such operation might take a long time on big projects with thousands of commits, this can't be confirmed at the moment, just a personal logical hypothesis
