### PR TITLE
feat: add silent mode

### DIFF
--- a/src/commit-changes.js
+++ b/src/commit-changes.js
@@ -5,13 +5,13 @@ import execa from 'execa'
 
 const { log } = console
 
-export const commitChanges = async ({ cwd, packageName, version, dryRun }) => {
+export const commitChanges = async ({ cwd, packageName, version, dryRun, silent }) => {
   if (dryRun) {
-    log(chalk`{yellow Skipping Git commit}`)
+    !silent && log(chalk`{yellow Skipping Git commit}`)
     return
   }
 
-  log(chalk`{blue Committing} CHANGELOG.md, package.json`)
+  !silent && log(chalk`{blue Committing} CHANGELOG.md, package.json`)
 
   // TODO: Deduplicate this
   const isMonorepoPackage = basename(cwd) === 'packages'

--- a/src/get-commits.js
+++ b/src/get-commits.js
@@ -13,7 +13,7 @@ const parserOptions = {
 
 const reBreaking = new RegExp(`(${parserOptions.noteKeywords.join(')|(')})`)
 
-export const getCommits = async ({ cwd, packageName, originTag }) => {
+export const getCommits = async ({ cwd, packageName, originTag, silent }) => {
   // TODO: Deduplicate this
   // TODO: replace `cwd` with `packagePath`
   const isMonorepoPackage = basename(cwd) === 'packages'
@@ -23,9 +23,10 @@ export const getCommits = async ({ cwd, packageName, originTag }) => {
   const fromTag = originTag || tags.pop()
   const toTag = originTag ? tags[tags.indexOf(originTag) + 1] + '~1' : 'HEAD'
 
-  originTag
-    ? log(chalk`{blue Gathering commits between} {grey ${fromTag} and {grey ${toTag}}}`)
-    : log(chalk`{blue Gathering commits since} {grey ${fromTag}}`)
+  !silent &&
+    (originTag
+      ? log(chalk`{blue Gathering commits between} {grey ${fromTag} and {grey ${toTag}}}`)
+      : log(chalk`{blue Gathering commits since} {grey ${fromTag}}`))
 
   // NOTE: ~1 means to not include release commit
   let params = ['--no-pager', 'log', `${fromTag}..${toTag}`, '--format=%B%n-hash-%n%H🐒💨🙊']

--- a/src/get-new-version.js
+++ b/src/get-new-version.js
@@ -3,8 +3,8 @@ import semver from 'semver'
 
 const { log } = console
 
-export const getNewVersion = (version, commits) => {
-  log(chalk`{blue Determining new version}`)
+export const getNewVersion = ({ version, commits, silent }) => {
+  !silent && log(chalk`{blue Determining new version}`)
   // TODO: Review
   const intersection = process.argv.filter(arg => ['--major', '--minor', '--patch'].includes(arg))
   if (intersection.length) return semver.inc(version, intersection[0].substring(2))

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // Updated with 521d776
 // https://github.com/rollup/plugins/commit/521d7767c9ded5c054d72c174a2c65ebc816ccc6
 
-import { join, basename } from 'path'
+import { join } from 'path'
 import { pathToFileURL } from 'url'
 
 import chalk from 'chalk'

--- a/src/index.js
+++ b/src/index.js
@@ -21,27 +21,27 @@ const { log } = console
 export const versionem = async options => {
   try {
     const parsedOptions = await parseOptions(options)
-    const { dryRun, regenChangelog, packageName, cwd } = parsedOptions
+    const { dryRun, regenChangelog, silent, packageName, cwd } = parsedOptions
 
     // FIXME: Problematic on Windows, requires `pathToFileURL`
     const { default: packageJson } = await import(pathToFileURL(join(cwd, 'package.json')))
 
-    dryRun && log(chalk`{magenta DRY RUN:} No files will be modified`)
+    !silent && dryRun && log(chalk`{magenta DRY RUN:} No files will be modified`)
 
     regenChangelog && (await regenerateChangelog(options))
 
-    log(chalk`{cyan Publishing \`${packageName}\`} from {grey packages/${packageName}}`)
+    !silent && log(chalk`{cyan Publishing \`${packageName}\`} from {grey packages/${packageName}}`)
 
     const commits = await getCommits({ packageName: packageName, ...parsedOptions })
 
     if (!commits.length)
       throw chalk`\n{red No commits found!} did you mean to publish ${packageName}?`
 
-    log(chalk`{blue Found} {bold ${commits.length}} commits`)
+    !silent && log(chalk`{blue Found} {bold ${commits.length}} commits`)
 
-    const newVersion = getNewVersion(packageJson.version, commits)
+    const newVersion = getNewVersion({ version: packageJson.version, commits, ...parsedOptions })
 
-    log(chalk`{blue New version}: ${newVersion}\n`)
+    !silent && log(chalk`{blue New version}: ${newVersion}\n`)
 
     await updatePackage({ packageJson, version: newVersion, ...parsedOptions })
     updateChangelog({ commits, version: newVersion, ...parsedOptions })

--- a/src/index.js
+++ b/src/index.js
@@ -21,24 +21,21 @@ const { log } = console
 export const versionem = async options => {
   try {
     const parsedOptions = await parseOptions(options)
+    const { dryRun, regenChangelog, packageName, cwd } = parsedOptions
 
     // FIXME: Problematic on Windows, requires `pathToFileURL`
-    const { default: packageJson } = await import(
-      pathToFileURL(join(parsedOptions.cwd, 'package.json'))
-    )
+    const { default: packageJson } = await import(pathToFileURL(join(cwd, 'package.json')))
 
-    parsedOptions.dryRun && log(chalk`{magenta DRY RUN:} No files will be modified`)
+    dryRun && log(chalk`{magenta DRY RUN:} No files will be modified`)
 
-    parsedOptions.regenChangelog && (await regenerateChangelog(options))
+    regenChangelog && (await regenerateChangelog(options))
 
-    log(
-      chalk`{cyan Publishing \`${parsedOptions.packageName}\`} from {grey packages/${parsedOptions.packageName}}`
-    )
+    log(chalk`{cyan Publishing \`${packageName}\`} from {grey packages/${packageName}}`)
 
-    const commits = await getCommits({ packageName: parsedOptions.packageName, ...parsedOptions })
+    const commits = await getCommits({ packageName: packageName, ...parsedOptions })
 
     if (!commits.length)
-      throw chalk`\n{red No commits found!} did you mean to publish ${parsedOptions.packageName}?`
+      throw chalk`\n{red No commits found!} did you mean to publish ${packageName}?`
 
     log(chalk`{blue Found} {bold ${commits.length}} commits`)
 

--- a/src/push.js
+++ b/src/push.js
@@ -3,13 +3,13 @@ import chalk from 'chalk'
 
 const { log } = console
 
-export const push = async ({ cwd, dryRun, noPush }) => {
+export const push = async ({ cwd, dryRun, noPush, silent }) => {
   if (dryRun || noPush) {
-    log(chalk`{yellow Skipping Git push}`)
+    !silent && log(chalk`{yellow Skipping Git push}`)
     return
   }
 
-  log(chalk`{blue Pushing release and tags}`)
+  !silent && log(chalk`{blue Pushing release and tags}`)
   await execa('git', ['push'], { cwd })
   await execa('git', ['push', '-f', '--tags'], { cwd })
 }

--- a/src/regenerate-changelog.js
+++ b/src/regenerate-changelog.js
@@ -9,8 +9,8 @@ import { getTags } from './get-tags'
 import { getCommits } from './get-commits'
 import { updateChangelog } from './update-changelog'
 
-export const regenerateChangelog = async ({ cwd, packageName }) => {
-  log(chalk`{magenta REGENERATE:} Changelog will be generated from scratch`)
+export const regenerateChangelog = async ({ cwd, packageName, silent }) => {
+  !silent && log(chalk`{magenta REGENERATE:} Changelog will be generated from scratch`)
 
   const tags = await getTags(packageName)
 
@@ -24,7 +24,7 @@ export const regenerateChangelog = async ({ cwd, packageName }) => {
     const [, version] = toTag.split('v')
     const commits = await getCommits(packageName, tag)
 
-    log(chalk`{blue Found} {bold ${commits.length}} commits`)
+    !silent && log(chalk`{blue Found} {bold ${commits.length}} commits`)
 
     updateChangelog(commits, cwd, packageName, version)
   }

--- a/src/regenerate-changelog.js
+++ b/src/regenerate-changelog.js
@@ -9,7 +9,7 @@ import { getTags } from './get-tags'
 import { getCommits } from './get-commits'
 import { updateChangelog } from './update-changelog'
 
-export const regenerateChangelog = async (cwd, packageName) => {
+export const regenerateChangelog = async ({ cwd, packageName }) => {
   log(chalk`{magenta REGENERATE:} Changelog will be generated from scratch`)
 
   const tags = await getTags(packageName)

--- a/src/tag.js
+++ b/src/tag.js
@@ -5,9 +5,9 @@ import { basename } from 'path'
 
 const { log } = console
 
-export const tag = async ({ cwd, packageName, version, dryRun, noTag }) => {
+export const tag = async ({ cwd, packageName, version, dryRun, noTag, silent }) => {
   if (dryRun || noTag) {
-    log(chalk`{yellow Skipping Git tag}`)
+    !silent && log(chalk`{yellow Skipping Git tag}`)
     return
   }
 
@@ -16,6 +16,6 @@ export const tag = async ({ cwd, packageName, version, dryRun, noTag }) => {
   const tagPrefix = isMonorepoPackage ? packageName + '-' : ''
 
   const tagName = `${tagPrefix}v${version}`
-  log(chalk`\n{blue Tagging} {grey ${tagName}}`)
+  !silent && log(chalk`\n{blue Tagging} {grey ${tagName}}`)
   await execa('git', ['tag', tagName], { cwd, stdio: 'inherit' })
 }

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -5,8 +5,8 @@ import chalk from 'chalk'
 
 const { log } = console
 
-export const updateChangelog = ({ commits, cwd, packageName, version, dryRun }) => {
-  log(chalk`{blue Gathering changes...}`)
+export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, silent }) => {
+  !silent && log(chalk`{blue Gathering changes...}`)
 
   // TODO: Deduplicate this
   const isMonorepoPackage = basename(cwd) === 'packages'
@@ -45,11 +45,11 @@ export const updateChangelog = ({ commits, cwd, packageName, version, dryRun }) 
   const newLog = parts.join('\n\n')
 
   if (dryRun) {
-    log(chalk`{blue New changelog}:\n${newLog}`)
+    !silent && log(chalk`{blue New changelog}:\n${newLog}`)
     return
   }
 
-  log(chalk`{blue Updating} CHANGELOG.md`)
+  !silent && log(chalk`{blue Updating} CHANGELOG.md`)
   const content = [title, newLog, oldNotes].filter(Boolean).join('\n\n')
   writeFileSync(logPath, content, 'utf-8')
 }

--- a/src/update-package.js
+++ b/src/update-package.js
@@ -3,13 +3,13 @@ import writePackage from 'write-pkg'
 
 const { log } = console
 
-export const updatePackage = async ({ cwd, packageJson, version, dryRun }) => {
+export const updatePackage = async ({ cwd, packageJson, version, dryRun, silent }) => {
   if (dryRun) {
-    log(chalk`{yellow Skipping package.json update}`)
+    !silent && log(chalk`{yellow Skipping package.json update}`)
     return
   }
 
-  log(chalk`{blue Updating} package.json`)
+  !silent && log(chalk`{blue Updating} package.json`)
 
   // A copy is necessary to allow directly making modifications to `package.json`
   const packageJsonCopy = Object.assign({}, packageJson)

--- a/tests/changelog.test.js
+++ b/tests/changelog.test.js
@@ -19,7 +19,7 @@ beforeAll(async () => {
 
 describe('changelog', () => {
   test('single chore', async () => {
-    await versionem({ cwd: exampleRepo, noPush: true })
+    await versionem({ cwd: exampleRepo, noPush: true, silent: true })
 
     const changelogPath = join(exampleRepo, 'CHANGELOG.md')
     const changelogContent = readFileSync(changelogPath, 'utf-8')


### PR DESCRIPTION
### Description

This suppress all kinds of output emitted from the CLI, except from errors (which are important to keep in every single situation, for both debugging and reporting needs)

### Use cases

Personally, my main motivation to implement such feature was to get rid of `console.log`'s on Jest output (which by the way, it's not enough with just it's `--silent` flag, as it also removes per-test green check), but it's not limited that, having a silent mode can open a bunch of possibilities that i'm not aware of at the moment for other users with specific scenarios and/or requirements