### PR TITLE
refactor: improve changelog generation module

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "execa": "^5.0.0",
     "minimist": "^1.2.5",
     "semver": "^7.3.4",
+    "sentence-case": "^3.0.4",
     "write-pkg": "^4.0.0"
   },
   "devDependencies": {

--- a/src/get-commits.js
+++ b/src/get-commits.js
@@ -18,7 +18,7 @@ export const getCommits = async ({ cwd, packageName, originTag, silent }) => {
   // TODO: replace `cwd` with `packagePath`
   const isMonorepoPackage = basename(cwd) === 'packages'
 
-  const tags = await getTags({ cwd, packageName })
+  const tags = await getTags(cwd, packageName)
 
   const fromTag = originTag || tags.pop()
   const toTag = originTag ? tags[tags.indexOf(originTag) + 1] + '~1' : 'HEAD'

--- a/src/get-tags.js
+++ b/src/get-tags.js
@@ -2,7 +2,7 @@ import { basename } from 'path'
 
 import execa from 'execa'
 
-export const getTags = async ({ cwd, packageName }) => {
+export const getTags = async (cwd, packageName) => {
   // TODO: Deduplicate this
   const isMonorepoPackage = basename(cwd) === 'packages'
   const tagPrefix = isMonorepoPackage ? packageName + '-' : ''

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export const versionem = async options => {
 
     !silent && dryRun && log(chalk`{magenta DRY RUN:} No files will be modified`)
 
-    regenChangelog && (await regenerateChangelog(options))
+    regenChangelog && (await regenerateChangelog(parsedOptions))
 
     !silent && log(chalk`{cyan Publishing \`${packageName}\`} from {grey packages/${packageName}}`)
 

--- a/src/regenerate-changelog.js
+++ b/src/regenerate-changelog.js
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { unlinkSync } from 'fs'
+import { existsSync, unlinkSync } from 'fs'
 
 import chalk from 'chalk'
 
@@ -9,23 +9,23 @@ import { getTags } from './get-tags'
 import { getCommits } from './get-commits'
 import { updateChangelog } from './update-changelog'
 
-export const regenerateChangelog = async ({ cwd, packageName, silent }) => {
+export const regenerateChangelog = async ({ cwd, packageName, silent, dryRun }) => {
   !silent && log(chalk`{magenta REGENERATE:} Changelog will be generated from scratch`)
 
-  const tags = await getTags(packageName)
+  const tags = await getTags(cwd, packageName)
 
   if (!tags.length) throw chalk`\n{red No Git tags found!}`
 
-  unlinkSync(join(cwd, 'CHANGELOG.md'))
+  existsSync && unlinkSync(join(cwd, 'CHANGELOG.md'))
 
   for (let [i, tag] of tags.entries()) {
     const toTag = tags[i + 1]
     if (!toTag) break
     const [, version] = toTag.split('v')
-    const commits = await getCommits(packageName, tag)
+    const commits = await getCommits({ cwd, packageName, originTag: tag, silent })
 
     !silent && log(chalk`{blue Found} {bold ${commits.length}} commits`)
 
-    updateChangelog(commits, cwd, packageName, version)
+    updateChangelog({ commits, cwd, packageName, version, dryRun, silent })
   }
 }

--- a/src/regenerate-changelog.js
+++ b/src/regenerate-changelog.js
@@ -16,7 +16,9 @@ export const regenerateChangelog = async ({ cwd, packageName, silent, dryRun }) 
 
   if (!tags.length) throw chalk`\n{red No Git tags found!}`
 
-  existsSync && unlinkSync(join(cwd, 'CHANGELOG.md'))
+  const logPath = join(cwd, 'CHANGELOG.md')
+
+  existsSync(logPath) && unlinkSync(logPath)
 
   for (let [i, tag] of tags.entries()) {
     const toTag = tags[i + 1]

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -20,16 +20,27 @@ export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, si
   const notes = { breaking: [], fixes: [], features: [], updates: [] }
 
   for (const { breaking, hash, header, type } of commits) {
+    // Prevent the inclusion of commits without types (eg: merge commits)
+    if (!type) continue
+
     // Issues in commit message, like: (#1)
     // Maybe transform these in links leading to actual issues/commits
     const ref = /\(#\d+\)/.test(header) ? '' : ` (${hash.substring(0, 7)})`
+
     // Remove package name as it's redundant inside the package changelog
     // Remove the commit type as it's redundant inside it's respective changelog section
     const message = header.trim().replace(`(${packageName})`, '').replace(`${type}: `, '') + ref
+
     if (breaking) notes.breaking.push(message)
-    else if (type === 'fix') notes.fixes.push(message)
-    else if (type === 'feat') notes.features.push(message)
-    else notes.updates.push(message)
+
+    switch (type) {
+      case 'fix':
+        notes.fixes.push(message)
+      case 'feat':
+        notes.features.push(message)
+      default:
+        notes.updates.push(message)
+    }
   }
 
   const parts = [

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -23,7 +23,6 @@ export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, si
   // TODO: load this from a external config
   const notes = {
     breakingChanges: {
-      prefix: 'docs',
       commits: []
     },
     features: {

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -2,6 +2,7 @@ import { join, basename } from 'path'
 import { readFileSync, writeFileSync, existsSync } from 'fs'
 
 import chalk from 'chalk'
+import { sentenceCase } from 'sentence-case'
 
 const { log } = console
 
@@ -17,11 +18,34 @@ export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, si
 
   const logFile = existsSync(logPath) ? readFileSync(logPath, 'utf-8') : ''
   const oldNotes = logFile.startsWith(title) ? logFile.slice(title.length).trim() : logFile
-  const notes = { breaking: [], fixes: [], features: [], updates: [] }
+  //const notes = { breaking: [], fixes: [], features: [], updates: [] }
+
+  // TODO: load this from a external config
+  const notes = {
+    breakingChanges: {
+      prefix: 'docs',
+      commits: []
+    },
+    features: {
+      prefix: 'feat',
+      commits: []
+    },
+    bugfixes: {
+      prefix: 'fix',
+      commits: []
+    },
+    updates: {
+      prefix: ['chore', 'refactor'],
+      commits: []
+    }
+  }
+
+  // TODO: add flag to allow including all commit types
+  const validCommitTypes = Object.values(notes).flatMap(({ prefix }) => prefix)
 
   for (const { breaking, hash, header, type } of commits) {
     // Prevent the inclusion of commits without types (eg: merge commits)
-    if (!type) continue
+    if (!validCommitTypes.includes(type)) continue
 
     // Issues in commit message, like: (#1)
     // Maybe transform these in links leading to actual issues/commits
@@ -31,26 +55,22 @@ export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, si
     // Remove the commit type as it's redundant inside it's respective changelog section
     const message = header.trim().replace(`(${packageName})`, '').replace(`${type}: `, '') + ref
 
-    if (breaking) notes.breaking.push(message)
-
-    switch (type) {
-      case 'fix':
-        notes.fixes.push(message)
-      case 'feat':
-        notes.features.push(message)
-      default:
-        notes.updates.push(message)
-    }
+    const getCategoryByPrefix = ([, { prefix }]) => prefix?.includes(type) || prefix === type
+    const [categoryName] = Object.entries(notes).filter(getCategoryByPrefix).flat()
+    const category = breaking || categoryName || 'updates'
+    notes[category].commits.push(message)
   }
 
-  const parts = [
-    `## v${version}`,
-    `_${date}_`,
-    notes.breaking.length ? `### Breaking changes\n\n- ${notes.breaking.join('\n- ')}`.trim() : '',
-    notes.fixes.length ? `### Bugfixes\n\n- ${notes.fixes.join('\n- ')}`.trim() : '',
-    notes.features.length ? `### Features\n\n- ${notes.features.join('\n- ')}`.trim() : '',
-    notes.updates.length ? `### Updates\n\n- ${notes.updates.join('\n- ')}`.trim() : ''
-  ].filter(Boolean) // remove those who are falsy (empty)
+  const categorizedCommits = Object.entries(notes)
+    .filter(([, { commits }]) => commits.length)
+    .map(([title, { commits }]) => {
+      const formattedTitle = `### ${sentenceCase(title)}\n\n`
+      const formattedCommits = '- ' + commits.join('\n- ').trim()
+      return formattedTitle + formattedCommits
+    })
+    .join('\n\n')
+
+  const parts = [`## v${version}`, `_${date}_`, categorizedCommits]
 
   // Divide sections with a line break
   const newLog = parts.join('\n\n')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2485,6 +2485,13 @@ lodash@^4.17.15, lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -2672,6 +2679,14 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3190,6 +3205,15 @@ semver@^7.3.2, semver@^7.3.4:
   dependencies:
     lru-cache "^6.0.0"
 
+sentence-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
+  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -3600,6 +3624,11 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
+tslib@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -3673,6 +3702,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+upper-case-first@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
+  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
+  dependencies:
+    tslib "^2.0.3"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
### Description

The highlights of this PR goes to the changelog categorization algorithm, previously, everything was done with a ugly and extensive `if-else` chain, and obviously, this is not scalable, now the `update-changelog.js` module counts with a dictionary with the following structure:

```typescript
interface SectionProperties {
    prefix?: string | string[]
    commits: string[]
}

type ReleaseSections = {
    [key in 'breakingChanges' | 'features' | 'bugfixes' | 'updates']: SectionProperties
}
```

### Considerations

As stated in https://github.com/henriquehbr/versionem/commit/54a1d5707a95bd821edd9c25d05c1beb0af4319e body

> ...and also opening new possibilities, like exposing a config file for users manually specifing changelog section titles and their respective commit prefixes

This means that the dictionary structure mentioned above might change in order to adapt to the config file integration seamlessly, it all depends on how such feature will be implemented on the project