### PR TITLE
feat: add --noCommit flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bin": "./src/cli.js",
   "scripts": {
     "release": "node --no-warnings --experimental-specifier-resolution=node src/cli",
-    "test": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest",
+    "test": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest -i --verbose --silent",
     "postinstall": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"

--- a/src/commit-changes.js
+++ b/src/commit-changes.js
@@ -5,8 +5,8 @@ import execa from 'execa'
 
 const { log } = console
 
-export const commitChanges = async ({ cwd, packageName, version, dryRun, silent }) => {
-  if (dryRun) {
+export const commitChanges = async ({ cwd, packageName, version, dryRun, noCommit, silent }) => {
+  if (dryRun || noCommit) {
     !silent && log(chalk`{yellow Skipping Git commit}`)
     return
   }

--- a/src/tag.js
+++ b/src/tag.js
@@ -5,8 +5,8 @@ import { basename } from 'path'
 
 const { log } = console
 
-export const tag = async ({ cwd, packageName, version, dryRun, noTag, silent }) => {
-  if (dryRun || noTag) {
+export const tag = async ({ cwd, packageName, version, dryRun, noCommit, noTag, silent }) => {
+  if (dryRun || noTag || noCommit) {
     !silent && log(chalk`{yellow Skipping Git tag}`)
     return
   }

--- a/tests/changelog.test.js
+++ b/tests/changelog.test.js
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, statSync } from 'fs'
 import { join } from 'path'
 
 import outdent from 'outdent'
@@ -10,26 +10,34 @@ import { dirname } from '../src/dirname'
 import { versionem } from '../src/index'
 
 const __dirname = dirname(import.meta.url)
-const exampleRepo = join(__dirname, 'example-repo')
+const exampleRepoPath = join(__dirname, 'example-repo')
 
 beforeAll(async () => {
-  existsSync(exampleRepo) && rimraf.sync(exampleRepo)
+  existsSync(exampleRepoPath) && rimraf.sync(exampleRepoPath)
   await generateExampleRepo()
 })
 
 describe('changelog', () => {
   test('single chore', async () => {
-    await versionem({ cwd: exampleRepo, noPush: true, silent: true })
+    writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')
 
-    const changelogPath = join(exampleRepo, 'CHANGELOG.md')
+    let params = ['add', '.']
+    await execa('git', params, { cwd: exampleRepoPath })
+
+    params = ['commit', '-m', 'chore: add "Hello World!"']
+    await execa('git', params, { cwd: exampleRepoPath })
+
+    await versionem({ cwd: exampleRepoPath, noPush: true, silent: true })
+
+    const changelogPath = join(exampleRepoPath, 'CHANGELOG.md')
     const changelogContent = readFileSync(changelogPath, 'utf-8')
 
     /* Use last modified time instead actual date to avoid possible 1% edge cases conflicts where
     the changelog is generated exactly 23:59 and the tests are run at 00:00 */
     const [lastModified] = statSync(changelogPath).mtime.toISOString().split('T')
 
-    let params = ['rev-parse', '--short', 'v0.0.1~1']
-    const { stdout: latestCommitHash } = await execa('git', params, { cwd: exampleRepo })
+    params = ['rev-parse', '--short', 'v0.0.1~1']
+    const { stdout: latestCommitHash } = await execa('git', params, { cwd: exampleRepoPath })
 
     const expectedChangelog = outdent`
       # Changelog

--- a/tests/changelog.test.js
+++ b/tests/changelog.test.js
@@ -17,29 +17,28 @@ beforeAll(async () => {
   await generateExampleRepo()
 })
 
-describe('changelog', () => {
-  test('single chore', async () => {
-    writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')
+it('Generates a single entry on "Updates" section', async () => {
+  writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')
 
-    let params = ['add', '.']
-    await execa('git', params, { cwd: exampleRepoPath })
+  let params = ['add', '.']
+  await execa('git', params, { cwd: exampleRepoPath })
 
-    params = ['commit', '-m', 'chore: add "Hello World!"']
-    await execa('git', params, { cwd: exampleRepoPath })
+  params = ['commit', '-m', 'chore: add "Hello World!"']
+  await execa('git', params, { cwd: exampleRepoPath })
 
-    await versionem({ cwd: exampleRepoPath, noPush: true, silent: true })
+  await versionem({ cwd: exampleRepoPath, noPush: true, silent: true })
 
-    const changelogPath = join(exampleRepoPath, 'CHANGELOG.md')
-    const changelogContent = readFileSync(changelogPath, 'utf-8')
+  const changelogPath = join(exampleRepoPath, 'CHANGELOG.md')
+  const changelogContent = readFileSync(changelogPath, 'utf-8')
 
-    /* Use last modified time instead actual date to avoid possible 1% edge cases conflicts where
+  /* Use last modified time instead actual date to avoid possible 1% edge cases conflicts where
     the changelog is generated exactly 23:59 and the tests are run at 00:00 */
-    const [lastModified] = statSync(changelogPath).mtime.toISOString().split('T')
+  const [lastModified] = statSync(changelogPath).mtime.toISOString().split('T')
 
-    params = ['rev-parse', '--short', 'v0.0.1~1']
-    const { stdout: latestCommitHash } = await execa('git', params, { cwd: exampleRepoPath })
+  params = ['rev-parse', '--short', 'v0.0.1~1']
+  const { stdout: latestCommitHash } = await execa('git', params, { cwd: exampleRepoPath })
 
-    const expectedChangelog = outdent`
+  const expectedChangelog = outdent`
       # Changelog
 
       ## v0.0.1
@@ -51,6 +50,5 @@ describe('changelog', () => {
       - add "Hello World!" (${latestCommitHash})
     `
 
-    expect(changelogContent).toBe(expectedChangelog)
-  })
+  expect(changelogContent).toBe(expectedChangelog)
 })

--- a/tests/generate-example-repo.js
+++ b/tests/generate-example-repo.js
@@ -1,6 +1,7 @@
 import { join } from 'path'
 
 import execa from 'execa'
+import writePkg from 'write-pkg'
 
 import { dirname } from '../src/dirname'
 
@@ -12,8 +13,7 @@ export const generateExampleRepo = async () => {
   let params = ['init', cwd]
   await execa('git', params)
 
-  params = ['init', '-y']
-  await execa('yarn', params, { cwd })
+  writePkg(cwd, { name: 'example-repo', version: '0.0.0' })
 
   params = ['add', '.']
   await execa('git', params, { cwd })

--- a/tests/generate-example-repo.js
+++ b/tests/generate-example-repo.js
@@ -1,4 +1,3 @@
-import { writeFile } from 'fs/promises'
 import { join } from 'path'
 
 import execa from 'execa'
@@ -26,13 +25,5 @@ export const generateExampleRepo = async () => {
   const { stdout: latestCommitHash } = await execa('git', params, { cwd })
 
   params = ['tag', 'v0.0.0', latestCommitHash]
-  await execa('git', params, { cwd })
-
-  writeFile(join(cwd, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')
-
-  params = ['add', '.']
-  await execa('git', params, { cwd })
-
-  params = ['commit', '-m', 'chore: add "Hello World!"']
   await execa('git', params, { cwd })
 }

--- a/tests/no-commit.test.js
+++ b/tests/no-commit.test.js
@@ -1,0 +1,41 @@
+import { existsSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import rimraf from 'rimraf'
+import execa from 'execa'
+
+import { generateExampleRepo } from './generate-example-repo'
+import { dirname } from '../src/dirname'
+import { versionem } from '../src/index'
+
+const __dirname = dirname(import.meta.url)
+const exampleRepoPath = join(__dirname, 'example-repo')
+
+beforeAll(async () => {
+  existsSync(exampleRepoPath) && rimraf.sync(exampleRepoPath)
+  await generateExampleRepo()
+})
+
+const getLatestCommitHash = async cwd => {
+  const params = ['rev-parse', '--short', 'HEAD']
+  const { stdout: latestCommitHash } = await execa('git', params, { cwd })
+  return latestCommitHash
+}
+
+it('--no-commit flag works properly', async () => {
+  writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')
+
+  let params = ['add', '.']
+  await execa('git', params, { cwd: exampleRepoPath })
+
+  params = ['commit', '-m', 'chore: add "Hello World!"']
+  await execa('git', params, { cwd: exampleRepoPath })
+
+  const beforeCommitHash = await getLatestCommitHash(exampleRepoPath)
+
+  await versionem({ cwd: exampleRepoPath, noCommit: true, noPush: true, silent: true })
+
+  const afterCommitHash = await getLatestCommitHash(exampleRepoPath)
+
+  expect(beforeCommitHash).toBe(afterCommitHash)
+})


### PR DESCRIPTION
### Description

Implements a new flag for controlling a particular part of the release process, more specifically, the commit, it behaves just like the existing ones (eg: `--noPush` and `--noTag`), except that it skips the commit step

### Use cases

It's really useful for having a more grained control on testing purposes, instead of skipping all release steps with `--dryRun`, you might skip only the commit to check if bumping and changelog generation are actually working properly

### Considerations

It might sounds a bit obvious, but a side-effect of the `--noCommit` flag is that it also skips the tagging step, so when used by itself, besides of preventing commits, this flag automatically behaves like `--noTag`, in the sense that it will also prevent git tags to be applied, because there will be no release commit to tag