### PR TITLE
feat: add --noBump flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ versionem [path] [--dryRun] [--noPush] [--noTag] [--regenChangelog] [--silent]
 - `--noPush`
   - Prevent pushing to remote after release
 - `--noCommit`
-  - Prevent from making a release commit (implicitly includes `--noTag`)
+  - Prevent release commit (implicitly includes `--noTag`)
 - `--noTag`
-  - Don't tag the release commit
+  - Prevent release commit from being tagged
+- `--noBump`
+  - Prevent `package.json#version` field from being updated
 - `--regenChangelog`
   - Regenerate all changelogs entries from scratch (overwriting existing ones), useful for existing codebases migrating to `versionem`
 - `--silent`

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,4 +1,6 @@
 const config = {
+  transform: {},
+  testEnvironment: 'jest-environment-node',
   moduleFileExtensions: ['js', 'mjs']
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bin": "./src/cli.js",
   "scripts": {
     "release": "node --no-warnings --experimental-specifier-resolution=node src/cli",
-    "test": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest -i --verbose --silent",
+    "test": "node --no-warnings --experimental-vm-modules node_modules/jest/bin/jest -i --verbose",
     "postinstall": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
@@ -26,6 +26,7 @@
     "@types/jest": "^26.0.20",
     "husky": "^5.1.1",
     "jest": "^26.6.3",
+    "jest-environment-node": "^26.6.2",
     "outdent": "^0.8.0",
     "pinst": "^2.1.6",
     "rimraf": "^3.0.2"

--- a/src/update-package.js
+++ b/src/update-package.js
@@ -3,8 +3,8 @@ import writePackage from 'write-pkg'
 
 const { log } = console
 
-export const updatePackage = async ({ cwd, packageJson, version, dryRun, silent }) => {
-  if (dryRun) {
+export const updatePackage = async ({ cwd, packageJson, version, dryRun, noBump, silent }) => {
+  if (dryRun || noBump) {
     !silent && log(chalk`{yellow Skipping package.json update}`)
     return
   }

--- a/tests/changelog.test.js
+++ b/tests/changelog.test.js
@@ -12,12 +12,10 @@ import { versionem } from '../src/index'
 const __dirname = dirname(import.meta.url)
 const exampleRepoPath = join(__dirname, 'example-repo')
 
-beforeAll(async () => {
+it('Generates a single entry on "Updates" section', async () => {
   existsSync(exampleRepoPath) && rimraf.sync(exampleRepoPath)
   await generateExampleRepo()
-})
 
-it('Generates a single entry on "Updates" section', async () => {
   writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')
 
   let params = ['add', '.']

--- a/tests/no-bump.test.js
+++ b/tests/no-bump.test.js
@@ -11,13 +11,15 @@ import { versionem } from '../src/index'
 const __dirname = dirname(import.meta.url)
 const exampleRepoPath = join(__dirname, 'example-repo')
 
-const getLatestCommitHash = async cwd => {
-  const params = ['rev-parse', '--short', 'HEAD']
-  const { stdout: latestCommitHash } = await execa('git', params, { cwd })
-  return latestCommitHash
+const getPackageJsonVersion = async cwd => {
+  const packageJsonPath = join(cwd, 'package.json')
+  const {
+    default: { version }
+  } = await import(packageJsonPath)
+  return version
 }
 
-it('--no-commit flag works properly', async () => {
+it('--noBump flag works properly', async () => {
   existsSync(exampleRepoPath) && rimraf.sync(exampleRepoPath)
   await generateExampleRepo()
 
@@ -29,11 +31,11 @@ it('--no-commit flag works properly', async () => {
   params = ['commit', '-m', 'chore: add "Hello World!"']
   await execa('git', params, { cwd: exampleRepoPath })
 
-  const beforeCommitHash = await getLatestCommitHash(exampleRepoPath)
+  const beforeVersion = await getPackageJsonVersion(exampleRepoPath)
 
-  await versionem({ cwd: exampleRepoPath, noCommit: true, noPush: true, silent: true })
+  await versionem({ cwd: exampleRepoPath, noPush: true, silent: true })
 
-  const afterCommitHash = await getLatestCommitHash(exampleRepoPath)
+  const afterVersion = await getPackageJsonVersion(exampleRepoPath)
 
-  expect(beforeCommitHash).toBe(afterCommitHash)
+  expect(beforeVersion).toBe(afterVersion)
 })


### PR DESCRIPTION
### Description

Implements a new flag for controlling a particular part of the release process, more specifically, the commit, it behaves just like the existing ones (eg: `--noPush`, `--noCommit`, `--noTag`), except that it skips the bump on `package.json#version` field

### Use cases

It's really useful for having a more grained control on testing purposes, instead of skipping all release steps with `--dryRun`, you might skip only the `package.json` version bump, might come in handy to check if other steps like commit, tagging or even pushing are being executed correctly