### PR TITLE
feat: add --noLog flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ versionem [path] [--dryRun] [--noPush] [--noTag] [--regenChangelog] [--silent]
   - Prevent pushing to remote after release
 - `--noCommit`
   - Prevent release commit (implicitly includes `--noTag`)
+- `--noLog`
+  - Prevent changelog from being generated
 - `--noTag`
   - Prevent release commit from being tagged
 - `--noBump`

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -6,7 +6,7 @@ import { sentenceCase } from 'sentence-case'
 
 const { log } = console
 
-export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, silent }) => {
+export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, noLog, silent }) => {
   !silent && log(chalk`{blue Gathering changes...}`)
 
   // TODO: Deduplicate this
@@ -74,7 +74,7 @@ export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, si
   // Divide sections with a line break
   const newLog = parts.join('\n\n')
 
-  if (dryRun) {
+  if (dryRun || noLog) {
     !silent && log(chalk`{blue New changelog}:\n${newLog}`)
     return
   }

--- a/tests/no-log.test.js
+++ b/tests/no-log.test.js
@@ -1,0 +1,31 @@
+import { existsSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+import rimraf from 'rimraf'
+import execa from 'execa'
+
+import { generateExampleRepo } from './generate-example-repo'
+import { dirname } from '../src/dirname'
+import { versionem } from '../src/index'
+
+const __dirname = dirname(import.meta.url)
+const exampleRepoPath = join(__dirname, 'example-repo')
+
+it('--noBump flag works properly', async () => {
+  existsSync(exampleRepoPath) && rimraf.sync(exampleRepoPath)
+  await generateExampleRepo()
+
+  writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')
+
+  let params = ['add', '.']
+  await execa('git', params, { cwd: exampleRepoPath })
+
+  params = ['commit', '-m', 'chore: add "Hello World!"']
+  await execa('git', params, { cwd: exampleRepoPath })
+
+  await versionem({ cwd: exampleRepoPath, noLog: true, noPush: true, silent: true })
+
+  const logPath = join(exampleRepoPath, 'CHANGELOG.md')
+
+  expect(existsSync(logPath)).toBeFalsy()
+})


### PR DESCRIPTION
### Description

Basically, the same line of behavior of other `--no` prefixed flags, except that it skips the changelog generation

### Use cases

Also the same of other `--no` prefixed flags, but specifically for disabling the changelog generation step, to check if other parts of the process are working fine