### PR TITLE
feat: add --publish flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ versionem [path] [--dryRun] [--noPush] [--noTag] [--regenChangelog] [--silent]
 
 ## Options
 
+- `--publish`
+  - Publishes the package to npm right after the release
 - `--dryRun`
   - Run the whole release process without making a single modification to existing files nor creating new ones
 - `--noPush`

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const { log } = console
 export const versionem = async options => {
   try {
     const parsedOptions = await parseOptions(options)
-    const { dryRun, regenChangelog, silent, packageName, cwd } = parsedOptions
+    const { dryRun, regenChangelog, publish, silent, packageName, cwd } = parsedOptions
 
     // FIXME: Problematic on Windows, requires `pathToFileURL`
     const { default: packageJson } = await import(pathToFileURL(join(cwd, 'package.json')))
@@ -30,7 +30,7 @@ export const versionem = async options => {
 
     regenChangelog && (await regenerateChangelog(parsedOptions))
 
-    !silent && log(chalk`{cyan Publishing \`${packageName}\`} from {grey packages/${packageName}}`)
+    !silent && log(chalk`{cyan Releasing \`${packageName}\`}`)
 
     const commits = await getCommits({ packageName: packageName, ...parsedOptions })
 
@@ -48,6 +48,7 @@ export const versionem = async options => {
     await commitChanges({ version: newVersion, ...parsedOptions })
     await tag({ version: newVersion, ...parsedOptions })
     await push(options)
+    publish && (await publish(options))
   } catch (e) {
     log(e)
   }

--- a/src/publish.js
+++ b/src/publish.js
@@ -1,0 +1,13 @@
+import chalk from 'chalk'
+import execa from 'execa'
+
+const { log } = console
+
+export const publish = async ({ cwd, packageName, dryRun, silent }) => {
+  !silent &&
+    log(
+      chalk`${dryRun ? `{yellow Skipping npm publish}` : `{blue Publishing ${packageName} to npm}`}`
+    )
+  let params = ['publish', dryRun ? '--dry-run' : '']
+  await execa('npm', params, { cwd })
+}


### PR DESCRIPTION
### Description

This flag automatically publishes the versioned package to npm, no more, no less

### Use case

Quoted from https://github.com/henriquehbr/versionem/commit/9120c25e07c8d051448d00fcd7b3c177745a2615:

> This ease the process of publishing packages to npm after the whole release process, and also saves the effort of adding something along the lines of `versionem && npm publish` or some extra scripting for such a mundane task