### PR TITLE
refactor: add JSDoc typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "type": "git",
     "url": "https://github.com/henriquehbr/versionem"
   },
-  "files": ["src"],
+  "files": [
+    "src"
+  ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
@@ -39,6 +41,7 @@
     "write-pkg": "^4.0.0"
   },
   "devDependencies": {
+    "@schemastore/package": "^0.0.6",
     "@types/jest": "^26.0.20",
     "husky": "^5.1.1",
     "jest": "^26.6.3",

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@ import minimist from 'minimist'
 
 import { versionem } from './index'
 
+/** @type {import('../types/options').Options} */
 const options = minimist(process.argv.slice(2))
 
 await versionem(options)

--- a/src/commit-changes.js
+++ b/src/commit-changes.js
@@ -5,6 +5,7 @@ import execa from 'execa'
 
 const { log } = console
 
+/** @type {import('../types/generic').Generic} */
 export const commitChanges = async ({ cwd, packageName, version, dryRun, noCommit, silent }) => {
   if (dryRun || noCommit) {
     !silent && log(chalk`{yellow Skipping Git commit}`)

--- a/src/dirname.js
+++ b/src/dirname.js
@@ -1,4 +1,5 @@
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+/** @type {(url: string) => string} */
 export const dirname = url => path.dirname(fileURLToPath(url))

--- a/src/get-commits.js
+++ b/src/get-commits.js
@@ -19,7 +19,7 @@ export const getCommits = async ({ cwd, packageName, originTag, silent }) => {
   // TODO: replace `cwd` with `packagePath`
   const isMonorepoPackage = basename(cwd) === 'packages'
 
-  const tags = await getTags(cwd, packageName)
+  const tags = await getTags({ cwd, packageName })
 
   const fromTag = originTag || tags.pop()
   const toTag = originTag ? tags[tags.indexOf(originTag) + 1] + '~1' : 'HEAD'

--- a/src/get-commits.js
+++ b/src/get-commits.js
@@ -13,6 +13,7 @@ const parserOptions = {
 
 const reBreaking = new RegExp(`(${parserOptions.noteKeywords.join(')|(')})`)
 
+/** @type {import('../types/generic').Generic} */
 export const getCommits = async ({ cwd, packageName, originTag, silent }) => {
   // TODO: Deduplicate this
   // TODO: replace `cwd` with `packagePath`

--- a/src/get-new-version.js
+++ b/src/get-new-version.js
@@ -3,6 +3,7 @@ import semver from 'semver'
 
 const { log } = console
 
+/** @type {import('../types/generic').Generic} */
 export const getNewVersion = ({ version, commits, silent }) => {
   !silent && log(chalk`{blue Determining new version}`)
   // TODO: Review

--- a/src/get-tags.js
+++ b/src/get-tags.js
@@ -2,8 +2,8 @@ import { basename } from 'path'
 
 import execa from 'execa'
 
-// TODO: transform this parameter into a object
-export const getTags = async (cwd, packageName) => {
+/** @type {import('../types/generic').Generic} */
+export const getTags = async ({ cwd, packageName }) => {
   // TODO: Deduplicate this
   const isMonorepoPackage = basename(cwd) === 'packages'
   const tagPrefix = isMonorepoPackage ? packageName + '-' : ''

--- a/src/get-tags.js
+++ b/src/get-tags.js
@@ -2,6 +2,7 @@ import { basename } from 'path'
 
 import execa from 'execa'
 
+// TODO: transform this parameter into a object
 export const getTags = async (cwd, packageName) => {
   // TODO: Deduplicate this
   const isMonorepoPackage = basename(cwd) === 'packages'

--- a/src/parse-options.js
+++ b/src/parse-options.js
@@ -1,5 +1,6 @@
 import { basename } from 'path'
 
+/** @type {import('../types/parse-options').ParseOptions} */
 export const parseOptions = options => {
   // Try retrieving from API parameter, then fallback to CLI flag, lastly get the cwd
   const cwd = options.cwd || options._?.[0] || process.cwd()

--- a/src/publish-npm.js
+++ b/src/publish-npm.js
@@ -3,6 +3,7 @@ import execa from 'execa'
 
 const { log } = console
 
+/** @type {import('../types/generic').Generic} */
 export const publishNpm = async ({ cwd, packageName, dryRun, silent }) => {
   !silent &&
     log(

--- a/src/push.js
+++ b/src/push.js
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 
 const { log } = console
 
+/** @type {import('../types/generic').Generic} */
 export const push = async ({ cwd, dryRun, noPush, silent }) => {
   if (dryRun || noPush) {
     !silent && log(chalk`{yellow Skipping Git push}`)

--- a/src/regenerate-changelog.js
+++ b/src/regenerate-changelog.js
@@ -13,7 +13,7 @@ import { updateChangelog } from './update-changelog'
 export const regenerateChangelog = async ({ cwd, packageName, silent, dryRun }) => {
   !silent && log(chalk`{magenta REGENERATE:} Changelog will be generated from scratch`)
 
-  const tags = await getTags(cwd, packageName)
+  const tags = await getTags({ cwd, packageName })
 
   if (!tags.length) throw chalk`\n{red No Git tags found!}`
 

--- a/src/regenerate-changelog.js
+++ b/src/regenerate-changelog.js
@@ -9,6 +9,7 @@ import { getTags } from './get-tags'
 import { getCommits } from './get-commits'
 import { updateChangelog } from './update-changelog'
 
+/** @type {import('../types/generic').Generic} */
 export const regenerateChangelog = async ({ cwd, packageName, silent, dryRun }) => {
   !silent && log(chalk`{magenta REGENERATE:} Changelog will be generated from scratch`)
 

--- a/src/tag.js
+++ b/src/tag.js
@@ -5,6 +5,7 @@ import { basename } from 'path'
 
 const { log } = console
 
+/** @type {import('../types/generic').Generic} */
 export const tag = async ({ cwd, packageName, version, dryRun, noCommit, noTag, silent }) => {
   if (dryRun || noTag || noCommit) {
     !silent && log(chalk`{yellow Skipping Git tag}`)

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -6,6 +6,7 @@ import { sentenceCase } from 'sentence-case'
 
 const { log } = console
 
+/** @type {import('../types/generic').Generic} */
 export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, noLog, silent }) => {
   !silent && log(chalk`{blue Gathering changes...}`)
 

--- a/src/update-package.js
+++ b/src/update-package.js
@@ -3,6 +3,7 @@ import writePackage from 'write-pkg'
 
 const { log } = console
 
+/** @type {import('../types/generic').Generic} */
 export const updatePackage = async ({ cwd, packageJson, version, dryRun, noBump, silent }) => {
   if (dryRun || noBump) {
     !silent && log(chalk`{yellow Skipping package.json update}`)

--- a/types/generic.d.ts
+++ b/types/generic.d.ts
@@ -1,0 +1,15 @@
+import type { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package'
+import type { Commit } from 'conventional-commits-parser'
+
+import { ParsedOptions } from './parse-options'
+
+type Commits = Commit<string | number | symbol>[]
+
+interface CustomParsedOptions extends ParsedOptions {
+  version?: string
+  packageJson?: JSONSchemaForNPMPackageJsonFiles
+  commits?: Commits
+  originTag: string
+}
+
+export type Generic = (options: CustomParsedOptions) => Promise<void>

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,0 +1,16 @@
+import type { ParsedArgs } from 'minimist'
+
+type Parameters =
+  | 'publish'
+  | 'dryRun'
+  | 'noPush'
+  | 'noCommit'
+  | 'noLog'
+  | 'noTag'
+  | 'noBump'
+  | 'regenChangelog'
+  | 'silent'
+
+type Options = ParsedArgs & Record<Parameters, boolean>
+
+export { Options }

--- a/types/parse-options.d.ts
+++ b/types/parse-options.d.ts
@@ -1,0 +1,10 @@
+import type { Options } from './options'
+
+interface ParsedOptions extends Options {
+  cwd: string
+  packageName: string
+}
+
+type ParseOptions = (options: Options) => Promise<ParsedOptions>
+
+export { ParseOptions, ParsedOptions }

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,6 +465,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@schemastore/package@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@schemastore/package/-/package-0.0.6.tgz#9a76713da1c7551293b7e72e4f387f802bfd5d81"
+  integrity sha512-uNloNHoyHttSSdeuEkkSC+mdxJXMKlcUPOMb//qhQbIQijXg8x54VmAw3jm6GJZQ5DBtIqGBd66zEQCDCChQVA==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"


### PR DESCRIPTION
### Description

This PR implements JSDoc types on all modules, some of the advantages of adding types to JS includes:

- Avoiding unexpected runtime errors
- Spotting bugs earlier
- Rich IDE support (VSCode's intellisense)
- Increase project overall predictability

### Considerations

Quoted from https://github.com/henriquehbr/versionem/commit/f0f92d48b0e10257b13688c2871d46ad29eb82d0:

> Besides adding support for types in JS, we can get rid of a build step and reduce output size (vanilla JS is way more compact than TS output) and have support for TS features, like conditional chaining, nullish coalescing operator and other syntactic sugars, all of this with ol' plain JSDoc