### PR TITLE
feat: add --unreleased flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ versionem [path] [--dryRun] [--noPush] [--noTag] [--regenChangelog] [--silent]
   - Publishes the package to npm right after the release
 - `--dryRun`
   - Run the whole release process without making a single modification to existing files nor creating new ones
+- `--unreleased`
+  - Includes to changelog commits created before a release (implicitly includes both `--noCommit` and `--noBump`)
 - `--noPush`
   - Prevent pushing to remote after release
 - `--noCommit`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ versionem [path] [--dryRun] [--noPush] [--noTag] [--regenChangelog] [--silent]
 - `--noPush`
   - Prevent pushing to remote after release
 - `--noCommit`
-  - Prevent release commit (implicitly includes `--noTag`)
+  - Prevent release commit (implicitly includes both `--noTag` and `--noPush`)
 - `--noLog`
   - Prevent changelog from being generated
 - `--noTag`

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "jest": "^26.6.3",
     "jest-environment-node": "^26.6.2",
     "outdent": "^0.8.0",
-    "pinst": "^2.1.6",
-    "rimraf": "^3.0.2"
+    "pinst": "^2.1.6"
   }
 }

--- a/src/commit-changes.js
+++ b/src/commit-changes.js
@@ -6,8 +6,16 @@ import execa from 'execa'
 const { log } = console
 
 /** @type {import('../types/generic').Generic} */
-export const commitChanges = async ({ cwd, packageName, version, dryRun, noCommit, silent }) => {
-  if (dryRun || noCommit) {
+export const commitChanges = async ({
+  cwd,
+  packageName,
+  unreleased,
+  version,
+  dryRun,
+  noCommit,
+  silent
+}) => {
+  if (dryRun || unreleased || noCommit) {
     !silent && log(chalk`{yellow Skipping Git commit}`)
     return
   }

--- a/src/get-new-version.js
+++ b/src/get-new-version.js
@@ -4,10 +4,8 @@ import semver from 'semver'
 const { log } = console
 
 /** @type {import('../types/generic').Generic} */
-export const getNewVersion = ({ version, commits, unreleased, silent }) => {
+export const getNewVersion = ({ version, commits, silent }) => {
   !silent && log(chalk`{blue Determining new version}`)
-
-  if (unreleased) return 'Unreleased'
 
   // TODO: Review
   const intersection = process.argv.filter(arg => ['--major', '--minor', '--patch'].includes(arg))

--- a/src/get-new-version.js
+++ b/src/get-new-version.js
@@ -4,8 +4,11 @@ import semver from 'semver'
 const { log } = console
 
 /** @type {import('../types/generic').Generic} */
-export const getNewVersion = ({ version, commits, silent }) => {
+export const getNewVersion = ({ version, commits, unreleased, silent }) => {
   !silent && log(chalk`{blue Determining new version}`)
+
+  if (unreleased) return 'Unreleased'
+
   // TODO: Review
   const intersection = process.argv.filter(arg => ['--major', '--minor', '--patch'].includes(arg))
   if (intersection.length) return semver.inc(version, intersection[0].substring(2))

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const { log } = console
 export const versionem = async options => {
   try {
     const parsedOptions = await parseOptions(options)
-    const { dryRun, regenChangelog, publish, silent, packageName, cwd } = parsedOptions
+    const { dryRun, regenChangelog, unreleased, publish, silent, packageName, cwd } = parsedOptions
 
     // FIXME: Problematic on Windows, requires `pathToFileURL`
     const { default: packageJson } = await import(pathToFileURL(join(cwd, 'package.json')))
@@ -40,7 +40,9 @@ export const versionem = async options => {
 
     !silent && log(chalk`{blue Found} {bold ${commits.length}} commits`)
 
-    const newVersion = getNewVersion({ version: packageJson.version, commits, ...parsedOptions })
+    const newVersion = unreleased
+      ? 'Unreleased'
+      : getNewVersion({ version: packageJson.version, commits, ...parsedOptions })
 
     !silent && log(chalk`{blue New version}: ${newVersion}\n`)
 

--- a/src/push.js
+++ b/src/push.js
@@ -4,8 +4,8 @@ import chalk from 'chalk'
 const { log } = console
 
 /** @type {import('../types/generic').Generic} */
-export const push = async ({ cwd, dryRun, noPush, silent }) => {
-  if (dryRun || noPush) {
+export const push = async ({ cwd, dryRun, noPush, noCommit, silent }) => {
+  if (dryRun || noCommit || noPush) {
     !silent && log(chalk`{yellow Skipping Git push}`)
     return
   }

--- a/src/tag.js
+++ b/src/tag.js
@@ -6,8 +6,17 @@ import { basename } from 'path'
 const { log } = console
 
 /** @type {import('../types/generic').Generic} */
-export const tag = async ({ cwd, packageName, version, dryRun, noCommit, noTag, silent }) => {
-  if (dryRun || noTag || noCommit) {
+export const tag = async ({
+  cwd,
+  unreleased,
+  packageName,
+  version,
+  dryRun,
+  noCommit,
+  noTag,
+  silent
+}) => {
+  if (dryRun || unreleased || noCommit || noTag) {
     !silent && log(chalk`{yellow Skipping Git tag}`)
     return
   }

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -32,6 +32,9 @@ export const updateChangelog = ({
 
   // TODO: load this from a external config
   const notes = {
+    unreleased: {
+      commits: []
+    },
     breakingChanges: {
       commits: []
     },
@@ -79,7 +82,8 @@ export const updateChangelog = ({
     })
     .join('\n\n')
 
-  const parts = [`## ${version}`, `_${date}_`, releaseContent]
+  // TODO: make this more readable
+  const parts = [`## ${version}`, ...(unreleased ? [] : [`_${date}_`]), releaseContent]
 
   // Divide sections with a line break
   const newLog = parts.join('\n\n')

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -7,7 +7,16 @@ import { sentenceCase } from 'sentence-case'
 const { log } = console
 
 /** @type {import('../types/generic').Generic} */
-export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, noLog, silent }) => {
+export const updateChangelog = ({
+  commits,
+  cwd,
+  unreleased,
+  packageName,
+  version,
+  dryRun,
+  noLog,
+  silent
+}) => {
   !silent && log(chalk`{blue Gathering changes...}`)
 
   // TODO: Deduplicate this
@@ -61,7 +70,9 @@ export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, no
     notes[category].commits.push(message)
   }
 
-  const categorizedCommits = Object.entries(notes)
+  const releaseTitle = (unreleased ? '' : '## v') + version
+
+  const releaseContent = Object.entries(notes)
     .filter(([, { commits }]) => commits.length)
     .map(([title, { commits }]) => {
       const formattedTitle = `### ${sentenceCase(title)}\n\n`
@@ -70,7 +81,7 @@ export const updateChangelog = ({ commits, cwd, packageName, version, dryRun, no
     })
     .join('\n\n')
 
-  const parts = [`## v${version}`, `_${date}_`, categorizedCommits]
+  const parts = [releaseTitle, `_${date}_`, releaseContent]
 
   // Divide sections with a line break
   const newLog = parts.join('\n\n')

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -70,8 +70,6 @@ export const updateChangelog = ({
     notes[category].commits.push(message)
   }
 
-  const releaseTitle = (unreleased ? '' : '## v') + version
-
   const releaseContent = Object.entries(notes)
     .filter(([, { commits }]) => commits.length)
     .map(([title, { commits }]) => {
@@ -81,7 +79,7 @@ export const updateChangelog = ({
     })
     .join('\n\n')
 
-  const parts = [releaseTitle, `_${date}_`, releaseContent]
+  const parts = [`## ${version}`, `_${date}_`, releaseContent]
 
   // Divide sections with a line break
   const newLog = parts.join('\n\n')

--- a/src/update-package.js
+++ b/src/update-package.js
@@ -4,8 +4,16 @@ import writePackage from 'write-pkg'
 const { log } = console
 
 /** @type {import('../types/generic').Generic} */
-export const updatePackage = async ({ cwd, packageJson, version, dryRun, noBump, silent }) => {
-  if (dryRun || noBump) {
+export const updatePackage = async ({
+  cwd,
+  packageJson,
+  unreleased,
+  version,
+  dryRun,
+  noBump,
+  silent
+}) => {
+  if (dryRun || unreleased || noBump) {
     !silent && log(chalk`{yellow Skipping package.json update}`)
     return
   }

--- a/tests/changelog.test.js
+++ b/tests/changelog.test.js
@@ -39,7 +39,7 @@ it('Generates a single entry on "Updates" section', async () => {
   const expectedChangelog = outdent`
       # Changelog
 
-      ## v0.0.1
+      ## 0.0.1
 
       _${lastModified}_
 

--- a/tests/changelog.test.js
+++ b/tests/changelog.test.js
@@ -1,8 +1,7 @@
-import { existsSync, readFileSync, writeFileSync, statSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, statSync, rmSync } from 'fs'
 import { join } from 'path'
 
 import outdent from 'outdent'
-import rimraf from 'rimraf'
 import execa from 'execa'
 
 import { generateExampleRepo } from './generate-example-repo'
@@ -13,7 +12,7 @@ const __dirname = dirname(import.meta.url)
 const exampleRepoPath = join(__dirname, 'example-repo')
 
 it('Generates a single entry on "Updates" section', async () => {
-  existsSync(exampleRepoPath) && rimraf.sync(exampleRepoPath)
+  existsSync(exampleRepoPath) && rmSync(exampleRepoPath, { recursive: true, force: true })
   await generateExampleRepo()
 
   writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')

--- a/tests/generate-example-repo.js
+++ b/tests/generate-example-repo.js
@@ -10,7 +10,7 @@ const __dirname = dirname(import.meta.url)
 export const generateExampleRepo = async () => {
   const cwd = join(__dirname, 'example-repo')
 
-  let params = ['init', cwd]
+  let params = ['init', '--shared=0777', cwd]
   await execa('git', params)
 
   writePkg(cwd, { name: 'example-repo', version: '0.0.0' })

--- a/tests/no-bump.test.js
+++ b/tests/no-bump.test.js
@@ -1,7 +1,6 @@
-import { existsSync, writeFileSync } from 'fs'
+import { existsSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
 
-import rimraf from 'rimraf'
 import execa from 'execa'
 
 import { generateExampleRepo } from './generate-example-repo'
@@ -20,7 +19,7 @@ const getPackageJsonVersion = async cwd => {
 }
 
 it('--noBump flag works properly', async () => {
-  existsSync(exampleRepoPath) && rimraf.sync(exampleRepoPath)
+  existsSync(exampleRepoPath) && rmSync(exampleRepoPath, { recursive: true, force: true })
   await generateExampleRepo()
 
   writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')

--- a/tests/no-commit.test.js
+++ b/tests/no-commit.test.js
@@ -1,7 +1,6 @@
-import { existsSync, writeFileSync } from 'fs'
+import { existsSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
 
-import rimraf from 'rimraf'
 import execa from 'execa'
 
 import { generateExampleRepo } from './generate-example-repo'
@@ -18,7 +17,7 @@ const getLatestCommitHash = async cwd => {
 }
 
 it('--no-commit flag works properly', async () => {
-  existsSync(exampleRepoPath) && rimraf.sync(exampleRepoPath)
+  existsSync(exampleRepoPath) && rmSync(exampleRepoPath, { recursive: true, force: true })
   await generateExampleRepo()
 
   writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')

--- a/tests/no-commit.test.js
+++ b/tests/no-commit.test.js
@@ -16,7 +16,7 @@ const getLatestCommitHash = async cwd => {
   return latestCommitHash
 }
 
-it('--no-commit flag works properly', async () => {
+it('--noCommit flag works properly', async () => {
   existsSync(exampleRepoPath) && rmSync(exampleRepoPath, { recursive: true, force: true })
   await generateExampleRepo()
 

--- a/tests/no-log.test.js
+++ b/tests/no-log.test.js
@@ -1,7 +1,6 @@
-import { existsSync, writeFileSync } from 'fs'
+import { existsSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
 
-import rimraf from 'rimraf'
 import execa from 'execa'
 
 import { generateExampleRepo } from './generate-example-repo'
@@ -12,7 +11,7 @@ const __dirname = dirname(import.meta.url)
 const exampleRepoPath = join(__dirname, 'example-repo')
 
 it('--noBump flag works properly', async () => {
-  existsSync(exampleRepoPath) && rimraf.sync(exampleRepoPath)
+  existsSync(exampleRepoPath) && rmSync(exampleRepoPath, { recursive: true, force: true })
   await generateExampleRepo()
 
   writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')

--- a/tests/no-log.test.js
+++ b/tests/no-log.test.js
@@ -10,7 +10,7 @@ import { versionem } from '../src/index'
 const __dirname = dirname(import.meta.url)
 const exampleRepoPath = join(__dirname, 'example-repo')
 
-it('--noBump flag works properly', async () => {
+it('--noLog flag works properly', async () => {
   existsSync(exampleRepoPath) && rmSync(exampleRepoPath, { recursive: true, force: true })
   await generateExampleRepo()
 

--- a/tests/unreleased.test.js
+++ b/tests/unreleased.test.js
@@ -1,0 +1,72 @@
+import { existsSync, writeFileSync, readFileSync, statSync, rmSync } from 'fs'
+import { join } from 'path'
+
+import execa from 'execa'
+import outdent from 'outdent'
+
+import { generateExampleRepo } from './generate-example-repo'
+import { dirname } from '../src/dirname'
+import { versionem } from '../src/index'
+
+const __dirname = dirname(import.meta.url)
+const exampleRepoPath = join(__dirname, 'example-repo')
+
+// TODO: create commit util for testing purposes that returns the hash
+it('--unreleased flag works properly', async () => {
+  existsSync(exampleRepoPath) && rmSync(exampleRepoPath, { recursive: true, force: true })
+  await generateExampleRepo()
+
+  const changelogPath = join(exampleRepoPath, 'CHANGELOG.md')
+
+  writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')
+
+  let params = ['add', '.']
+  await execa('git', params, { cwd: exampleRepoPath })
+
+  params = ['commit', '-m', 'chore: add "Hello World!"']
+  await execa('git', params, { cwd: exampleRepoPath })
+
+  params = ['rev-parse', '--short', 'HEAD']
+  const { stdout: firstCommitHash } = await execa('git', params, { cwd: exampleRepoPath })
+
+  await versionem({ cwd: exampleRepoPath, noPush: true, silent: true })
+
+  /* Use last modified time instead actual date to avoid possible 1% edge cases conflicts where
+    the changelog is generated exactly 23:59 and the tests are run at 00:00 */
+  const [lastModified] = statSync(changelogPath).mtime.toISOString().split('T')
+
+  writeFileSync(join(exampleRepoPath, 'lipsum.js'), 'console.log("Lipsum!")\n', 'utf-8')
+
+  params = ['add', '.']
+  await execa('git', params, { cwd: exampleRepoPath })
+
+  params = ['commit', '-m', 'feat: add "Lipsum"']
+  await execa('git', params, { cwd: exampleRepoPath })
+
+  params = ['rev-parse', '--short', 'HEAD']
+  const { stdout: secondCommitHash } = await execa('git', params, { cwd: exampleRepoPath })
+
+  await versionem({ cwd: exampleRepoPath, unreleased: true, noPush: true, silent: true })
+
+  const changelogContent = readFileSync(changelogPath, 'utf-8')
+
+  const expectedChangelog = outdent`
+    # Changelog
+
+    ## Unreleased
+
+    ### Features
+
+    - add "Lipsum" (${secondCommitHash})
+
+    ## 0.0.1
+
+    _${lastModified}_
+
+    ### Updates
+
+    - add "Hello World!" (${firstCommitHash})
+  `
+
+  expect(expectedChangelog).toBe(changelogContent)
+})

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -3,6 +3,7 @@ import type { ParsedArgs } from 'minimist'
 type Parameters =
   | 'publish'
   | 'dryRun'
+  | 'unreleased'
   | 'noPush'
   | 'noCommit'
   | 'noLog'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3137,7 +3137,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
### Description

Quoted from https://github.com/henriquehbr/versionem/commit/b28d54e9494b3655cbdfe55b303bd8901a001a34:

> In short, this will allow to include commits that were made before a release on a separated changelog section called "Unreleased"...

### Use cases

Also quoted from https://github.com/henriquehbr/versionem/commit/b28d54e9494b3655cbdfe55b303bd8901a001a34:

> ...this is intended to be used alongside Git hooks, to automate the process of listing unreleased/wip commit before every-commit, more specifically, on the `pre-commit` hook