### PR TITLE
feat: add links on commit hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- add link on commit hashes ([HEAD](https://github.com/henriquehbr/versionem/commit/HEAD))
+- add link on commit hashes ([bef6038](https://github.com/henriquehbr/versionem/commit/bef6038))
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## Unreleased
 
+### Features
+
+- add link on commit hashes ([HEAD](https://github.com/henriquehbr/versionem/commit/HEAD))
+
 ### Updates
 
-- modularize commit categorization and changelog formatting (HEAD)
-- modularize changelog entry formatter (86a98dd)
+- modularize commit categorization and changelog formatting ([a7eaedd](https://github.com/henriquehbr/versionem/commit/a7eaedd))
+- modularize changelog entry formatter ([86a98dd](https://github.com/henriquehbr/versionem/commit/86a98dd))
 
 ## 0.9.2
 

--- a/src/categorize-commits.js
+++ b/src/categorize-commits.js
@@ -1,5 +1,7 @@
 import execa from 'execa'
 
+import { getRemoteUrl } from './get-remote-url'
+
 export const categorizeCommits = async ({ cwd, packageName, commits, unreleased }) => {
   const commitCategories = {
     unreleased: {
@@ -25,18 +27,20 @@ export const categorizeCommits = async ({ cwd, packageName, commits, unreleased 
   // TODO: add flag to allow including all commit types
   const validCommitTypes = Object.values(commitCategories).flatMap(({ prefix }) => prefix)
 
-  const params = ['rev-parse', 'HEAD']
+  let params = ['rev-parse', 'HEAD']
   const { stdout: latestCommitHash } = await execa('git', params, { cwd })
 
   for (const { breaking, hash, header, type } of commits) {
     // Prevent the inclusion of commits without types (eg: merge commits)
     if (!validCommitTypes.includes(type)) continue
 
+    const remoteUrl = await getRemoteUrl(cwd)
     const commitHash = unreleased && hash === latestCommitHash ? 'HEAD' : hash.substring(0, 7)
+    const commitUrl = remoteUrl ? `[${commitHash}](${remoteUrl}/commit/${commitHash})` : commitHash
 
     // Issues in commit message, like: (#1)
     // Maybe transform these in links leading to actual issues/commits
-    const ref = /\(#\d+\)/.test(header) ? '' : ` (${commitHash})`
+    const ref = /\(#\d+\)/.test(header) ? '' : ` (${commitUrl})`
 
     // Remove package name as it's redundant inside the package changelog
     // Remove the commit type as it's redundant inside it's respective changelog section

--- a/src/get-remote-url.js
+++ b/src/get-remote-url.js
@@ -1,0 +1,16 @@
+import execa from 'execa'
+import readPkg from 'read-pkg'
+
+export const getRemoteUrl = async cwd => {
+  const packageJson = await readPkg({ cwd, normalize: false })
+
+  if (packageJson?.repository?.url) return packageJson.repository.url
+
+  try {
+    const params = ['config', '--get', 'remote.origin.url']
+    const { stdout: remoteUrl } = await execa('git', params, { cwd })
+    return remoteUrl
+  } catch {
+    return ''
+  }
+}

--- a/tests/commit-hash-url.test.js
+++ b/tests/commit-hash-url.test.js
@@ -1,0 +1,67 @@
+import { writeFileSync, readFileSync, statSync } from 'fs'
+import { join } from 'path'
+
+import execa from 'execa'
+import outdent from 'outdent'
+
+import { dirname } from '../src/dirname'
+import { versionem } from '../src/index'
+import { generateExampleRepo } from './utils/generate-example-repo'
+import { commit } from './utils/commit'
+
+const __dirname = dirname(import.meta.url)
+const exampleRepoPath = join(__dirname, 'example-repo')
+
+it('properly fetch remote repo url for commit hash links', async () => {
+  await generateExampleRepo()
+
+  writeFileSync(join(exampleRepoPath, 'index.js'), 'console.log("Hello World!")\n', 'utf-8')
+  const firstCommitHash = await commit('chore: hello world', { cwd: exampleRepoPath })
+
+  await versionem({ cwd: exampleRepoPath, noPush: true, silent: true })
+
+  let params = ['remote', 'add', 'origin', 'https://github.com/henriquehbr/versionem']
+  await execa('git', params, { cwd: exampleRepoPath })
+
+  writeFileSync(join(exampleRepoPath, 'foobar.js'), 'console.log("foobar")\n', 'utf-8')
+  const secondCommitHash = await commit('feat: foobar', { cwd: exampleRepoPath })
+
+  writeFileSync(join(exampleRepoPath, 'lipsum.js'), 'console.log("lorem ipsum")\n', 'utf-8')
+  await commit('fix: lipsum', { cwd: exampleRepoPath })
+
+  await versionem({ cwd: exampleRepoPath, unreleased: true, noPush: true, silent: true })
+
+  const changelogPath = join(exampleRepoPath, 'CHANGELOG.md')
+  const changelogContent = readFileSync(changelogPath, 'utf-8')
+
+  /* Use last modified time instead actual date to avoid possible 1% edge cases conflicts where
+    the changelog is generated exactly 23:59 and the tests are run at 00:00 */
+  const [lastModified] = statSync(changelogPath).mtime.toISOString().split('T')
+
+  params = ['config', '--get', 'remote.origin.url']
+  const { stdout: remoteUrl } = await execa('git', params, { cwd: exampleRepoPath })
+
+  const expectedChangelog = outdent`
+    # Changelog
+
+    ## Unreleased
+
+    ### Features
+
+    - foobar ([${secondCommitHash}](${remoteUrl}/commit/${secondCommitHash}))
+
+    ### Bugfixes
+
+    - lipsum ([HEAD](${remoteUrl}/commit/HEAD))
+
+    ## 0.0.1
+
+    _${lastModified}_
+
+    ### Updates
+
+    - hello world (${firstCommitHash})
+  `
+
+  expect(changelogContent).toBe(expectedChangelog)
+})


### PR DESCRIPTION
### Description

This add clickable links to changelog commit hashes that leads to their remote version

### Use case

This one is a good to have feature in almost all situations, mainly to check if the commit hashes on the local repository are correct and properly represent their remote counterparts

### Considerations

Quoted from https://github.com/henriquehbr/versionem/commit/bef60380eacd5de194d8f7ec31ff8bb7549fed92:

> the way they're retrieved is by checking on `package.json#repository#url` first, if such field is not present, then the actual git repository is verified, if nothing is found, the remote url fallbacks to a empty string, consequently not rendering links on the changelog output