### PR TITLE
feat: add --force flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- add --force flag ([HEAD](https://github.com/henriquehbr/versionem/commit/HEAD))
+
 ## 0.10.5
 
 _2021-03-15_

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ versionem [path] [--dryRun] [--noPush] [--noTag] [--regenChangelog] [--silent]
   - Run the whole release process without making a single modification to existing files nor creating new ones
 - `--unreleased`
   - Includes to changelog commits created before a release (implicitly includes both `--noCommit` and `--noBump`)
+- `--force`
+  - Force release even when there aren't eligible commits
 - `--noPush`
   - Prevent pushing to remote after release
 - `--noCommit`

--- a/src/format-changelog-entry.js
+++ b/src/format-changelog-entry.js
@@ -28,6 +28,11 @@ export const formatChangelogEntry = async ({
     formattedChangelogEntry.push(formattedNote)
   }
 
+  !formattedChangelogEntry.length &&
+    formattedChangelogEntry.push(
+      '- Only refactorings and dev-only changes were made on this release'
+    )
+
   if (!unreleased) {
     let date = ''
 

--- a/src/get-commits.js
+++ b/src/get-commits.js
@@ -7,7 +7,7 @@ import { parseCommits } from './parse-commits'
 const { log } = console
 
 /** @type {import('../types/generic').Generic} */
-export const getCommits = async ({ cwd, packageName, originTag, silent }) => {
+export const getCommits = async ({ cwd, force, packageName, originTag, silent }) => {
   const tags = await getTags({ cwd, packageName })
 
   const fromTag = originTag || tags.pop()
@@ -27,7 +27,7 @@ export const getCommits = async ({ cwd, packageName, originTag, silent }) => {
 
   const parsedCommits = parseCommits({ cwd, unparsedCommits })
 
-  if (!parsedCommits.length)
+  if (!parsedCommits.length && !force)
     throw new Error(
       chalk`\n{yellow No eligible commits found!} are you following a commit naming standard?`
     )

--- a/tests/force-unknown.test.js
+++ b/tests/force-unknown.test.js
@@ -1,0 +1,54 @@
+import { join } from 'path'
+import { statSync, readFileSync } from 'fs'
+
+import { outdent } from 'outdent'
+
+import { dirname } from '../src/dirname'
+import { versionem } from '../src/index'
+import { generateExampleRepo } from './utils/generate-example-repo'
+import { commit } from './utils/commit'
+
+const __dirname = dirname(import.meta.url)
+const exampleRepoPath = join(__dirname, 'example-repo')
+
+it('Force release with unknown commits', async () => {
+  await generateExampleRepo()
+
+  const firstCommitHash = await commit('chore: hello world', { cwd: exampleRepoPath })
+  await versionem({ cwd: exampleRepoPath, noPush: true, silent: true })
+
+  const changelogPath = join(exampleRepoPath, 'CHANGELOG.md')
+
+  /* Use last modified time instead actual date to avoid possible 1% edge cases conflicts where
+  the changelog is generated exactly 23:59 and the tests are run at 00:00 */
+  const [lastModified] = statSync(changelogPath).mtime.toISOString().split('T')
+
+  await commit('alpha: lipsum', { cwd: exampleRepoPath })
+  await versionem({
+    cwd: exampleRepoPath,
+    force: true,
+    unreleased: true,
+    noPush: true,
+    silent: true
+  })
+
+  const changelogContent = readFileSync(changelogPath, 'utf-8')
+
+  const expectedChangelog = outdent`
+    # Changelog
+
+    ## Unreleased
+
+    - Only refactorings and dev-only changes were made on this release
+
+    ## 0.0.1
+
+    _${lastModified}_
+
+    ### Updates
+
+    - hello world (${firstCommitHash})
+  `
+
+  expect(changelogContent).toBe(expectedChangelog)
+})


### PR DESCRIPTION
### Description

Quoted from 8033582:

> This allows to make releases even when they don't contain eligible
commits, like `chore`, `test`, `build` or other prefixes non-included by
default on versionem category metadata, when a release is forced without
eligible commits (including `--unreleased`), the following message is
displayed instead of changes list:
>
> - Only refactorings and dev-only changes were made on this release

### Considerations

Also quoted from 8033582:

> This opens a new window for possible implementation of a config file,
consequently allowing user-defined commit types, and even a custom
release placeholder message instead the default one specified above