### PR TITLE
feat: add --releasePlaceholder flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- add --releasePlaceholder flag ([HEAD](https://github.com/henriquehbr/versionem/commit/HEAD))
+
 ## 0.11.0
 
 _2021-03-16_

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ versionem [path] [--dryRun] [--noPush] [--noTag] [--regenChangelog] [--silent]
   - Includes to changelog commits created before a release (implicitly includes both `--noCommit` and `--noBump`)
 - `--force`
   - Force release even when there aren't eligible commits
+- `--releasePlaceholder`
+  - Use a custom message for releases that doesn't contain eligible commits
 - `--noPush`
   - Prevent pushing to remote after release
 - `--noCommit`

--- a/src/format-changelog-entry.js
+++ b/src/format-changelog-entry.js
@@ -9,6 +9,7 @@ import execa from 'execa'
 export const formatChangelogEntry = async ({
   cwd,
   unreleased,
+  releasePlaceholder,
   packageName,
   version,
   categorizedCommits
@@ -30,7 +31,9 @@ export const formatChangelogEntry = async ({
 
   !formattedChangelogEntry.length &&
     formattedChangelogEntry.push(
-      '- Only refactorings and dev-only changes were made on this release'
+      `- ${
+        releasePlaceholder || 'Only refactorings and dev-only changes were made on this release'
+      }`
     )
 
   if (!unreleased) {

--- a/src/update-changelog.js
+++ b/src/update-changelog.js
@@ -15,6 +15,7 @@ export const updateChangelog = async ({
   cwd,
   unreleased,
   packageName,
+  releasePlaceholder,
   previousVersion,
   version,
   dryRun,
@@ -38,6 +39,7 @@ export const updateChangelog = async ({
   const formattedChangelogEntry = await formatChangelogEntry({
     cwd,
     unreleased,
+    releasePlaceholder,
     previousVersion,
     packageName,
     version,

--- a/tests/release-placeholder.test.js
+++ b/tests/release-placeholder.test.js
@@ -1,0 +1,55 @@
+import { join } from 'path'
+import { statSync, readFileSync } from 'fs'
+
+import { outdent } from 'outdent'
+
+import { dirname } from '../src/dirname'
+import { versionem } from '../src/index'
+import { generateExampleRepo } from './utils/generate-example-repo'
+import { commit } from './utils/commit'
+
+const __dirname = dirname(import.meta.url)
+const exampleRepoPath = join(__dirname, 'example-repo')
+
+it('Display custom placeholder message on release with unknown commits', async () => {
+  await generateExampleRepo()
+
+  const firstCommitHash = await commit('chore: hello world', { cwd: exampleRepoPath })
+  await versionem({ cwd: exampleRepoPath, noPush: true, silent: true })
+
+  const changelogPath = join(exampleRepoPath, 'CHANGELOG.md')
+
+  /* Use last modified time instead actual date to avoid possible 1% edge cases conflicts where
+  the changelog is generated exactly 23:59 and the tests are run at 00:00 */
+  const [lastModified] = statSync(changelogPath).mtime.toISOString().split('T')
+
+  await commit('alpha: lipsum', { cwd: exampleRepoPath })
+  await versionem({
+    cwd: exampleRepoPath,
+    force: true,
+    unreleased: true,
+    releasePlaceholder: 'No notable changes here',
+    noPush: true,
+    silent: true
+  })
+
+  const changelogContent = readFileSync(changelogPath, 'utf-8')
+
+  const expectedChangelog = outdent`
+    # Changelog
+
+    ## Unreleased
+
+    - No notable changes here
+
+    ## 0.0.1
+
+    _${lastModified}_
+
+    ### Updates
+
+    - hello world (${firstCommitHash})
+  `
+
+  expect(changelogContent).toBe(expectedChangelog)
+})


### PR DESCRIPTION
### Description

Quoted from 3b8cf40:

> Allows customization on the message shown in releases that doesn't contains any eligible commits (or their types are unknown to versionem commit categorization algorithm)

### Use cases

Also quoted from 3b8cf40:

> This gives more flexibility when noticing that notable changes didn't happened in a specific version, or even for compatiblity purposes of old projects that for some reason had releases published without features, bugfixes, chores or breaking changes

### Considerations

The occurrence of release made without eligible commits (those containing unknown types for `versionem`), might reduce in a near future with the possible implementation of a config file that allows the user to specify the commit types used in the projects, and to which category/commit prefixes they're related